### PR TITLE
ci: point the CI workflow at BHoM/CI_Toolkit

### DIFF
--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Run build
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-build@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-build@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
@@ -35,7 +35,7 @@ jobs:
       actions: write
     steps:
       - name: Run copyright compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: copyright
           patterns: '*.cs'
@@ -51,10 +51,10 @@ jobs:
       actions: write
     steps:
       - name: Run project compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: project
-          patterns: 'AssemblyInfo.cs *.csproj'
+          patterns: '*AssemblyInfo.cs *.csproj'
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
 
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Run serialisation
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-serialisation@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-serialisation@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}


### PR DESCRIPTION
CI_Toolkit moved from BuroHappoldEngineeringAdmin to BHoM. The old path redirects, so this removes a dependency on the redirect rather than fixing a break.

Also picks up a pattern correction made since this file was copied: project compliance matches `AssemblyInfo.cs` at any depth instead of only at the repo root. It does not change which files are selected in this repo today.

Still non-blocking. Tracked in CI_Toolkit_Proxy#13.